### PR TITLE
skip test if pdflatex not found

### DIFF
--- a/tests/testthat/test-swclose.R
+++ b/tests/testthat/test-swclose.R
@@ -1,5 +1,5 @@
 test_that("swclose works", {
-  skip_on_ci()
+  skip_if(Sys.which("pdflatex") == "", "pdflatex was not found")
   withr::with_tempdir({
     pdfDocument <- swopen(outfile = "test.pdf")
     swlatex(pdfDocument, "tttteeeesssstttt")


### PR DESCRIPTION
`skip_on_ci()` did not work on r-universe, also checking for pdflatex is a more specific solution