### PR TITLE
Fix creation of validation pdf 

### DIFF
--- a/R/lusweavedata.R
+++ b/R/lusweavedata.R
@@ -1,7 +1,7 @@
 #' lusweavedata
 #' @description General lusweave-dataset
 #' @aliases lusweavedata
-#' @details Pleasde do not directly acces that data. It should be only used by library functions.
+#' @details Please do not directly access that data. It should be only used by library functions.
 #' @author Jan Philipp Dietrich
 #' @name lusweavedata
 #'

--- a/R/swclose.R
+++ b/R/swclose.R
@@ -15,7 +15,7 @@
 #' they remain, including each plot in its own pdf.
 #' @param engine Engine to use for conversion. Currently available: Sweave and
 #' knitr.
-#' @param save_stream If true (default) stream is saved to .rda file.
+#' @param save_stream If true (default is false) stream is saved to .rda file.
 #' @param knitquiet If false (default) progressbar and messages are printed
 #' otherwise suppressed.
 #' @return No return value.
@@ -33,7 +33,7 @@
 #' }
 #'
 # method to create a pdf from the swStream object
-swclose <- function(stream, outfile = "", latexpath = "", clean_output = TRUE, engine = "knitr", save_stream = TRUE, knitquiet = TRUE) {
+swclose <- function(stream, outfile = "", latexpath = "", clean_output = TRUE, engine = "knitr", save_stream = FALSE, knitquiet = TRUE) {
   # Write "content" (extended by "\end{document}")to an Rnw file,
   # sweave this file and produce the pdf from the .tex file. Then delete the sweaveStream
   if (is.environment(stream)) {

--- a/R/swfigure.R
+++ b/R/swfigure.R
@@ -53,7 +53,11 @@ swfigure <- function(stream, plot_func, ..., tex_caption = "", tex_label = "", f
     if (fig.placement != "") startplot <- paste(startplot, "[", fig.placement, "]", sep = "")
     startplot <- c(startplot, "\\begin{center}")
     swlatex(envir, startplot)
-    swR(envir, plot_func, ..., option = paste(sw_label, ",fig=TRUE,echo=FALSE", sep = ""))
+    # The following includes flags that disable warnings and messages for figures.
+    # This is due a potential defect in knitr that results in invalid LaTeX (yihui/knitr/issues/2412). 
+    # The warnings and messages should be re-enabled as soon as the knitr issue is resolved.
+    # -- patrick.rein (2025-07-15)
+    swR(envir, plot_func, ..., option = paste(sw_label, ",fig=TRUE,echo=FALSE,warning=FALSE,message=FALSE", sep=""))
     endplot <- "\\end{center}"
     if (tex_caption != "") endplot <- c(endplot, paste("\\caption{", gsub("$", "\\$", tex_caption, fixed = TRUE), "}", sep = ""))
     if (tex_label != "") endplot <- c(endplot, paste("\\label{", gsub("$", "\\$", tex_label, fixed = TRUE), "}", sep = ""))


### PR DESCRIPTION
This PR is part of a series of changes in multiple packages that repair the generation of the validation pdf.

In particular, this PR:
- disables messages and warnings for figures, as it results in invalid LaTeX (can be reverted when the underlying potential knitr issue is resolved)
- deactivates writing the validation pdf stream into an rda file by default, as it is seldom needed but takes very long

